### PR TITLE
Blog share buttons are not sticky on safari [#1299]

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -80,8 +80,8 @@ $(function() {
   };
 
   function stickOnResize() {
-    let element = $('.js-sidebar-signup');
-    let normalSidebarCSS = {
+    var element = $('.js-sidebar-signup');
+    var normalSidebarCSS = {
       'position': 'initial',
       'margin-top': '',
       'width': '',


### PR DESCRIPTION
- We were using `let` which isn't supported in older safari versions