### PR TITLE
Make SVG files on blog searchable [#1591]

### DIFF
--- a/_includes/svg.html
+++ b/_includes/svg.html
@@ -1,3 +1,3 @@
 <object data="{{ include.svg_path }}" type="image/svg+xml">
-  <img src="{{ site.baseurl }}/{{ include.svg_path }}" />
+  <img src="{{ include.svg_path }}" />
 </object>

--- a/_includes/svg.html
+++ b/_includes/svg.html
@@ -1,0 +1,3 @@
+<object data="{{ include.svg_path }}" type="image/svg+xml">
+  <img src="{{ site.baseurl }}/{{ include.svg_path }}" />
+</object>

--- a/_posts/2016-10-10-what-is-agile-and-are-we-agile-yet.md
+++ b/_posts/2016-10-10-what-is-agile-and-are-we-agile-yet.md
@@ -17,7 +17,9 @@ Nevertheless, with time many Agile projects started to feel as formal and conser
 
 So how did Agile come to dominance and is it now more dogma than direction? Inspired by [Andy Budd](http://www.andybudd.com/archives/2016/08/are_we_moving_towards_a_postagile_age/), in this infographic we ponder the post-agile age, which drives upon the best elements of agile, waterfall and lean development. 
 
-![age-of-agile.svg](/assets/images/age-of-agile.svg)
+{% include svg.html
+  svg_path="/assets/images/age-of-agile.svg"
+%}
 
 ## What is pre-Agile software development?
 

--- a/_posts/2017-07-20-hr-cheatsheet.md
+++ b/_posts/2017-07-20-hr-cheatsheet.md
@@ -16,9 +16,14 @@ Hiring developers is tough. Especially for HR people coming from non-technical b
 
 If you have ever been confused about where Sinatra and Laravel belong, and if Scala is a Java framework (hint: it’s not), have a look at our cheatsheet. Refer to it anytime during screening and interviewing developers!
 
+{% include svg.html
+  svg_path="/assets/images/cheat-sheet-glossary.svg"
+%}
 
-![hr-cheatsheet-glossary](/assets/images/cheat-sheet-glossary.svg)
+{% include svg.html
+  svg_path="/assets/images/cheat-sheet-frontend.svg"
+%}
 
-![hr-cheatsheet-frontend](/assets/images/cheat-sheet-frontend.svg)
-
-![hr-cheatsheet-backend](/assets/images/cheat-sheet-backend.svg)
+{% include svg.html
+  svg_path="/assets/images/cheat-sheet-backend.svg"
+%}

--- a/_sass/app/views/_post.scss
+++ b/_sass/app/views/_post.scss
@@ -110,7 +110,8 @@ $sticky-icon-size: 40px;
       color: $black-color;
     }
 
-    img {
+    img,
+    object {
       width: 100%;
     }
   }


### PR DESCRIPTION
- Svg imges are now hosted as svg objects with img as a fallback

- [x] https://github.com/honeypotio/honeypot/issues/1591