### PR TITLE
remove json gem as the bundler supports it by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ ruby File.read(File.expand_path('../.ruby-version', __FILE__)).chop
 
 gem 'jekyll'
 gem 'rake'
-gem 'json', '2.0.2'
 gem 'liquid', '3.0.6'
 gem 'jekyll-paginate'
 gem 'github-pages', '140'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,6 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0)
-    json (2.0.2)
     kramdown (1.13.2)
     liquid (3.0.6)
     listen (3.0.6)
@@ -207,13 +206,12 @@ DEPENDENCIES
   github-pages (= 140)
   jekyll
   jekyll-paginate
-  json (= 2.0.2)
   liquid (= 3.0.6)
   rack-jekyll
   rake
 
 RUBY VERSION
-   ruby 2.4.1p111
+   ruby 2.5.3p105
 
 BUNDLED WITH
    1.15.1


### PR DESCRIPTION
I get an error running jekly serve:
```
➜  blog-honeypot-io git:(fix/remove-json-gem) ✗ jekyll serve
Traceback (most recent call last):
	10: from /Users/russellsnyder/.rbenv/versions/2.5.3/bin/jekyll:23:in `<main>'
	 9: from /Users/russellsnyder/.rbenv/versions/2.5.3/bin/jekyll:23:in `load'
	 8: from /Users/russellsnyder/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/jekyll-3.4.3/exe/jekyll:9:in `<top (required)>'
	 7: from /Users/russellsnyder/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/jekyll-3.4.3/lib/jekyll/plugin_manager.rb:36:in `require_from_bundler'
	 6: from /Users/russellsnyder/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/bundler-1.15.1/lib/bundler.rb:101:in `setup'
	 5: from /Users/russellsnyder/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/bundler-1.15.1/lib/bundler/runtime.rb:27:in `setup'
	 4: from /Users/russellsnyder/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/bundler-1.15.1/lib/bundler/runtime.rb:27:in `map'
	 3: from /Users/russellsnyder/.rbenv/versions/2.5.3/lib/ruby/2.5.0/forwardable.rb:229:in `each'
	 2: from /Users/russellsnyder/.rbenv/versions/2.5.3/lib/ruby/2.5.0/forwardable.rb:229:in `each'
	 1: from /Users/russellsnyder/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/bundler-1.15.1/lib/bundler/runtime.rb:32:in `block in setup'
/Users/russellsnyder/.rbenv/versions/2.5.3/lib/ruby/gems/2.5.0/gems/bundler-1.15.1/lib/bundler/runtime.rb:317:in `check_for_activated_spec!': You have already activated json 2.1.0, but your Gemfile requires json 2.0.2. Since json is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports json as a default gem. (Gem::LoadError)
```

removing the json gem solves this error.  This is probably from upgrading the ruby version locally