### PR TITLE
Use correct linkedin link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -18,7 +18,7 @@
         <a href="https://www.facebook.com/Honeypotio/" target="_blank">
           <i class="fa fa-facebook"></i>
         </a>
-        <a href="https://www.linkedin.com/company/honeypot" target="_blank">
+        <a href="https://www.linkedin.com/company/honeypotio" target="_blank">
           <i class="fa fa-linkedin"></i>
         </a>
       </div>


### PR DESCRIPTION
The linkedin link in the footer is using an incorrect URL... since 5 years ago 🤦 