### PR TITLE
[HONEY-5940] Remove CTAs and Recruiter links to Honeypot

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,7 +2,6 @@
 layout: default
 ---
 {% assign author = site.data.authors[page.author] %}
-{% assign cta = site.data.post_cta[page.cta] %}
 
 <div class="container">
   <div class="row">
@@ -89,13 +88,11 @@ layout: default
           linkedin=author.social.linkedin
         %}
 
-        {% include sign-up.html cta=cta %}
       </div><!-- ./post -->
     </div><!-- ./col-md-9 -->
 
     <div class="col-md-3">
       {% include featured-posts.html %}
-      {% include sidebar-signup.html %}
     </div>
 
     <div class="col-md-9">

--- a/_posts/2015-12-28-interview-questions-for-a-frontend-developer.md
+++ b/_posts/2015-12-28-interview-questions-for-a-frontend-developer.md
@@ -77,6 +77,4 @@ Another [GitHub repository][2]{:target="_blank"} of interview questions for fron
 
 [1]: https://github.com/h5bp/Front-end-Developer-Interview-Questions
 [2]: https://github.com/khan4019/front-end-Interview-Questions
-[3]: https://www.honeypot.io/pages/for_employers?utm_source=blog&utm_medium=organic&utm_term=g&utm_content=151203&utm_campaign=hr-no
-[4]: https://www.honeypot.io/invite_requests/new?invitation_type=company&utm_source=blogfe
 

--- a/_posts/2015-12-29-why-you-should-hire-more-female-developers.md
+++ b/_posts/2015-12-29-why-you-should-hire-more-female-developers.md
@@ -77,4 +77,3 @@ While individual and structural obstacles can be difficult to overcome and certa
 [6]: https://www.honeypot.io
 [7]: https://app.honeypot.io/users/sign_up?utm_source=blog&utm_medium=organic&utm_term=e&utm_content=151204&utm_campaign=dev-no
 [8]: https://app.honeypot.io/users/sign_up?utm_source=blog&utm_medium=organic&utm_term=e&utm_content=151204&utm_campaign=dev-no
-[9]: https://www.honeypot.io/invite_requests/new?invitation_type=company&utm_source=blogwm

--- a/_posts/2016-01-14-this-is-what-it-takes-to-become-a-berlin-cto.md
+++ b/_posts/2016-01-14-this-is-what-it-takes-to-become-a-berlin-cto.md
@@ -74,7 +74,4 @@ Berlin CTO salaries range from as little as €58,000 to as much as €142,000 f
 
 * * *
 
-**[Join Honeypot][2] and make your next hire within 28 days.**
-
-[2]: https://www.honeypot.io/pages/for_employers?utm_source=blog&utm_medium=organic&utm_term=f&utm_content=160103&utm_campaign=com-no
-[1]: https://www.honeypot.io/invite_requests/new?utm_source=blogc
+**Join Honeypot and make your next hire within 28 days.**

--- a/_posts/2016-07-19-5-things-developers-want-to-know-before-accepting-a-job-offer.md
+++ b/_posts/2016-07-19-5-things-developers-want-to-know-before-accepting-a-job-offer.md
@@ -39,15 +39,12 @@ How did everything start? Developers want to know the story behind the company. 
 What makes your company culture so special? Developers value  friendly and fun work environments which encourage learning. Don’t forget the amazing perks you offer. Oh, and that tech meetup you attend every month. Add some nice images from your office space and your team events to your careers page. That way developers can imagine  themselves right there!
 
 
-Taking a user-centric approach to your interview process will boost your company’s reputation as a friendly place to work. On [Honeypot][1], every company hiring developers has a company profile, listing these five key elements. Companies with more detailed profiles have their interview invitations and job offers accepted at a significantly higher rate. 
+Taking a user-centric approach to your interview process will boost your company’s reputation as a friendly place to work. On Honeypot, every company hiring developers has a company profile, listing these five key elements. Companies with more detailed profiles have their interview invitations and job offers accepted at a significantly higher rate. 
 
 Get into a culture of pitching your company during the interview process with developers - in the end it's not just the developer who has to convince you, you have to convince the developer!
 
 
 * * * 
 
-### Honeypot is a developer-focused job platform. Use Honeypot to filter by location, tech stack and salary and contact your favourite candidates directly. Sign-up to [start hiring][2] skilled and pre-screened developers today!
+### Honeypot is a developer-focused job platform. Use Honeypot to filter by location, tech stack and salary and contact your favourite candidates directly. Sign-up to start hiring skilled and pre-screened developers today!
 
-
-[1]: https://www.honeypot.io/pages/for_employers?utm_source=blog5
-[2]: https://www.honeypot.io/invite_requests/new?utm_source=blog5

--- a/_posts/2020-07-21-reverse-recruitment.md
+++ b/_posts/2020-07-21-reverse-recruitment.md
@@ -127,4 +127,4 @@ You will increase the number of qualified candidates when you actively source de
 
 It’s no secret that there are more barriers to hiring exceptional tech talent than in other professions, and as the scarcity of tech talent increases globally, every company should focus on optimising their tech recruitment metrics. 
 
-Whether your goal is to reduce time-to-fill, to increase your number of qualified candidates, or reduce your cost - reverse recruitment is the way to go! Curious? Then sign up to [Honeypot](https://www.honeypot.io/en/tech-hiring)!
+Whether your goal is to reduce time-to-fill, to increase your number of qualified candidates, or reduce your cost - reverse recruitment is the way to go! Curious? Then sign up to Honeypot!

--- a/_posts/2022-07-25-introducing-new-roles.md
+++ b/_posts/2022-07-25-introducing-new-roles.md
@@ -55,8 +55,8 @@ decisions.
 
 ## Alright, how should I start?
 
-Well, the first prerequisite would be [signing up to
-Honeypot](https://app.honeypot.io/invite_requests/new). When
+Well, the first prerequisite would be signing up to
+Honeypot. When
 that's out of the way, follow these easy steps:
 
 * Log in;

--- a/_posts/2022-09-27-tech-salaries-report-germany-2022.md
+++ b/_posts/2022-09-27-tech-salaries-report-germany-2022.md
@@ -60,7 +60,3 @@ In order to get the **full picture** and break down tech salaries further by gen
   label="Get the Tech Salaries Report 2022"
   url="https://hello.honeypot.io/tech-salary-report-germany-2022/"
 %}
-
-<br />
-
-**Need extra help finding top tech talent?** [Honeypot has you covered](https://www.honeypot.io/en/tech-hiring?utm_source=blog).

--- a/_posts/2023-01-19-How-to-find-senior-developers.md
+++ b/_posts/2023-01-19-How-to-find-senior-developers.md
@@ -85,4 +85,4 @@ By the same token, senior software engineers tend not to suffer fools gladly. Co
 
 ## Get help from the experts
 
-Let Honeypot be your expert partner, helping you find and win the tech talents for your vacant positions. [Sign up and get instant access](https://www.honeypot.io/en/tech-hiring) to our vast database of senior software developers, updated with new, verified candidates on a weekly basis.
+Let Honeypot be your expert partner, helping you find and win the tech talents for your vacant positions.

--- a/_posts/2023-09-08-reverse-recruitinig-de.md
+++ b/_posts/2023-09-08-reverse-recruitinig-de.md
@@ -125,4 +125,4 @@ Die aktive Personalbeschaffung erhöht bekanntlich die Zahl der geeigneten Kandi
 
 Es ist kein Geheimnis, dass die Hürden bei der Gewinnung von herausragenden Tech-Talenten höher sind als in anderen Tätigkeitsfeldern. Mit dem zunehmenden Fachkräftemangel vor allem im Technologiesektor muss sich jedes Unternehmen wieder auf die Optimierung seiner Personalabläufe besinnen.
 
-Ganz gleich, ob es darum geht, Time-to-Fill-Zeiten zu verkürzen, mehr qualifizierte Bewerber anzuziehen oder die Kosten der Stellenausschreibung zu senken: Reverse Recruiting ist der richtige Weg! Neugierig geworden? Dann melde dich an bei [Honeypot](https://www.honeypot.io/en/tech-hiring)!
+Ganz gleich, ob es darum geht, Time-to-Fill-Zeiten zu verkürzen, mehr qualifizierte Bewerber anzuziehen oder die Kosten der Stellenausschreibung zu senken: Reverse Recruiting ist der richtige Weg! Neugierig geworden? Dann melde dich an bei Honeypot!


### PR DESCRIPTION
- feat: remove CTAs from posts
- feat: remove references to B2B form and Recruiter website pages
